### PR TITLE
Fix clsx spread; add install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+First, install dependencies and run the development server:
 
 ```bash
+npm install
 npm run dev
 # or
 yarn dev

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,5 +2,5 @@ import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(...inputs))
 }


### PR DESCRIPTION
## Summary
- fix arg spread in `cn` utility for tailwind
- document installing dependencies before running dev server

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p .` *(fails to find packages)*

------
https://chatgpt.com/codex/tasks/task_b_684952d2289c832dbcb8e36b105817ae